### PR TITLE
Argon2id support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: go
 
 go:
   - 1.9.3
-  - latest
+  - stable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Crypt implementation in pure Go
 ```go
 func main() {
 	password := "password"
-	settings := "$argon2i$v=19$m=65536,t=2,p=4$c2FsdHNhbHQ" // salt = "saltsalt"
+	settings := "$argon2id$v=19$m=65536,t=2,p=4$c2FsdHNhbHQ" // salt = "saltsalt"
 
 	encoded, err := crypt.Crypt(password, settings)
 	if err != nil {
@@ -18,21 +18,24 @@ func main() {
 	}
 
 	fmt.Println(encoded)
-	// Output: $argon2i$v=19$m=65536,t=2$c2FsdHNhbHQ$YPZdL78ZgqtxD1bLxAjRySEFfYb3Y1BOQQWFW6sT0Vo
+	// Output: $argon2id$v=19$m=65536,t=2,p=4$c2FsdHNhbHQ$mxUf7CB5gEwtDSiHfZCvxj17E8XeTFh2fpti1ioD3SA
 }
 ```
 
 # Algorithm
 
-Currently, the following algorithms are supported
+Currently, the following algorithms are supported:
 
-| Code    | Name    | Example                                                                                              |
-|---------|---------|------------------------------------------------------------------------------------------------------|
-|       1 | MD5     | $1$deadbeef$Q7g0UO4hRC0mgQUQ/qkjZ0                                                                   |
-|       5 | SHA256  | $5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5                                            |
-|       6 | SHA512  | $6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1 |
-|      2a | bcrypt  | $2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq                                         |
-| argon2i | Argon2i | $argon2i$v=19$m=65536,t=2$c29tZXNhbHQ$IMit9qkFULCMA/ViizL57cnTLOa5DiVM9eMwpAvPwr4                    |
+|  Code    | Name     | Example                                                                                              |
+|----------|----------|------------------------------------------------------------------------------------------------------|
+|        1 | MD5      | $1$deadbeef$Q7g0UO4hRC0mgQUQ/qkjZ0                                                                   |
+|        5 | SHA256   | $5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5                                            |
+|        6 | SHA512   | $6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1 |
+|       2a | bcrypt   | $2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq                                         |
+|  argon2i | Argon2i  | $argon2i$v=19$m=65536,t=2$c29tZXNhbHQ$IMit9qkFULCMA/ViizL57cnTLOa5DiVM9eMwpAvPwr4                    |
+| argon2id | Argon2id | $argon2id$v=19$m=65536,t=2,p=4$c29tZXNhbHQ$GpZ3sK/oH9p7VIiV56G/64Zo/8GaUw434IimaPqxwCo               |
+
+It's recommended that you used `argon2id` for crypting passwords.
 
 # Links
 

--- a/argon2id.go
+++ b/argon2id.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Philipp Brüll (pb@simia.tech)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// There are a few differences between our handling of argon2id and argon2i.
+// The argon2id implementation is written to emulate the PHC winning
+// implementation (https://github.com/P-H-C/phc-winner-argon2).
+
+// Argon2idPrefix defines the settings prefix for argon2id hashes.
+const Argon2idPrefix = "$argon2id$"
+
+func init() {
+	RegisterAlgorithm(Argon2idPrefix, argon2idAlgorithm)
+}
+
+const (
+	argon2idDefaultMemory   = 32 * 1024
+	argon2idDefaultTime     = 1
+	argon2idDefaultThreads  = 4
+	argon2idKeySize         = 32
+	argon2idDefaultSaltSize = 16
+)
+
+// Argon2idSettings returns argon2id settings with the provided parameter.
+func Argon2idSettings(m, t, p int, salts ...string) (string, error) {
+	settings := fmt.Sprintf("%sv=19$m=%d,t=%d,p=%d", Argon2idPrefix, m, t, p)
+	salt := strings.Join(salts, "")
+	if salt == "" {
+		b := make([]byte, argon2idDefaultSaltSize)
+		rand.Read(b)
+		salt = Base64Encoding.EncodeToString(b)
+	}
+	return settings + "$" + salt, nil
+}
+
+func argon2idAlgorithm(password, settings string) (string, error) {
+	passwordBytes := []byte(password)
+	_, parameter, salt, _, err := DecodeSettings(settings)
+	if err != nil {
+		return "", err
+	}
+	saltBytes := []byte{}
+	if salt == "" {
+		saltBytes = make([]byte, argon2idDefaultSaltSize)
+		rand.Read(saltBytes)
+	} else {
+		saltBytes, err = Base64Encoding.DecodeString(salt)
+		if err != nil {
+			return "", fmt.Errorf("base64 decode [%s]: %v", salt, err)
+		}
+	}
+	memory := parameter.GetInt("m", argon2idDefaultMemory)
+	time := parameter.GetInt("t", argon2idDefaultTime)
+	threads := parameter.GetInt("p", argon2idDefaultThreads)
+
+	hash := argon2.IDKey(passwordBytes, saltBytes, uint32(time), uint32(memory), uint8(threads), argon2idKeySize)
+
+	buf := bytes.Buffer{}
+	buf.Write([]byte(Argon2idPrefix))
+	buf.WriteString("v=19$")
+	buf.WriteString("m="+strconv.Itoa(memory)+",")
+	buf.WriteString("t="+strconv.Itoa(time)+",")
+	buf.WriteString("p="+strconv.Itoa(threads))
+	buf.WriteString("$")
+	buf.WriteString(Base64Encoding.EncodeToString(saltBytes))
+	buf.WriteString("$")
+	buf.WriteString(Base64Encoding.EncodeToString(hash))
+	return buf.String(), nil
+}

--- a/argon2id_test.go
+++ b/argon2id_test.go
@@ -1,0 +1,98 @@
+// Copyright 2018 Philipp Brüll (pb@simia.tech)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypt_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/simia-tech/crypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgon2id(t *testing.T) {
+	tcs := []struct {
+		password       string
+		settings       string
+		expectedResult string
+		expectedErr    error
+	}{
+		{
+			"generate salt",
+			"$argon2id$v=19$m=65536,t=2,p=4$",
+			"$argon2id$v=19$m=65536,t=2,p=4$",
+			nil,
+		},
+		{
+			"password", // salt = somesalt
+			"$argon2id$v=19$m=65536,t=2,p=4$c29tZXNhbHQ",
+			"$argon2id$v=19$m=65536,t=2,p=4$c29tZXNhbHQ$GpZ3sK/oH9p7VIiV56G/64Zo/8GaUw434IimaPqxwCo",
+			nil,
+		},
+		{
+			"another password", // salt = anothersalt
+			"$argon2id$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ",
+			"$argon2id$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ$ZU9gSnQfqeEZG2Wu6Wq9pek2UAttI/N8NLCEecVBRZc",
+			nil,
+		},
+		{
+			"password", // salt = longsaltlongsaltlong
+			"$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc",
+			"$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$y3Tz6SCUIw7occvkgsUYx0hwaePXLus7rxUzsOghhnE",
+			nil,
+		},
+		{
+			"ignore-hash-in-settings", // salt = longsaltlongsaltlong
+			"$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$y3Tz6SCUIw7occvkgsUYx0hwaePXLus7rxUzsOghhnE",
+			"$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$sToxuMqIBNNRYEPy2Gh690R7qa7mkhJ627ciTZdyQSA",
+			nil,
+		},
+		{
+			"password", // salt = longsaltlongsalt
+			"$argon2id$v=19$m=65536,t=3,p=1$bG9uZ3NhbHRsb25nc2FsdA",
+			"$argon2id$v=19$m=65536,t=3,p=1$bG9uZ3NhbHRsb25nc2FsdA$SHogC8dbNGlyrOIJTrZ4f0/r/ZmTglvCx4u5GUzw6EM",
+			nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.settings, func(t *testing.T) {
+			result, err := crypt.Crypt(tc.password, tc.settings)
+			require.Equal(t, tc.expectedErr, err)
+			assert.True(t, strings.HasPrefix(result, tc.expectedResult), "expected prefix %q, got %q", tc.expectedResult, result)
+		})
+	}
+}
+
+func TestArgon2idSettings(t *testing.T) {
+	tcs := []struct {
+		m                      int
+		t                      int
+		p                      int
+		expectedSettingsPrefix string
+	}{
+		{65536, 2, 4, "$argon2id$v=19$m=65536,t=2,p=4"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("m=%d,t=%d,p=%d", tc.m, tc.t, tc.p), func(t *testing.T) {
+			settings, err := crypt.Argon2idSettings(tc.m, tc.t, tc.p)
+			require.NoError(t, err)
+			assert.True(t, strings.HasPrefix(settings, tc.expectedSettingsPrefix))
+		})
+	}
+}


### PR DESCRIPTION
This adds support for the argon2id algorithm, which seems to be the [preferred algorithm][] for general use and password encryption. (See issue #1.)

There are a few differences between this implementation and the argon2i implementation:

 * No maximum salt size.
 * Include parameters in output regardless of whether they match the defaults.

These match the output from the [winning implementation][] of the Password Hashing Contest.

I, Daniel Parks, transfer all copyrights I have on this code to Philipp Brüll.

[winning implementation]: https://github.com/P-H-C/phc-winner-argon2
[prefered algorithm]: https://tools.ietf.org/html/draft-irtf-cfrg-argon2-02#section-4