### PR TITLE
Always append m/t/p for argon2i/argon2id

### DIFF
--- a/argon2i.go
+++ b/argon2i.go
@@ -75,15 +75,11 @@ func argon2iAlgorithm(password, settings string) (string, error) {
 	hash := argon2.Key(passwordBytes, saltBytes, uint32(time), uint32(memory), uint8(threads), uint32(keySize))
 
 	p := []string{}
-	if memory != argon2iDefaultMemory {
-		p = append(p, "m="+strconv.Itoa(memory))
-	}
-	if time != argon2iDefaultTime {
-		p = append(p, "t="+strconv.Itoa(time))
-	}
-	if threads != argon2iDefaultThreads {
-		p = append(p, "p="+strconv.Itoa(threads))
-	}
+
+	p = append(p, "m="+strconv.Itoa(memory))
+	p = append(p, "t="+strconv.Itoa(time))
+	p = append(p, "p="+strconv.Itoa(threads))
+
 	if keySize != argon2iDefaultKeySize {
 		p = append(p, "k="+strconv.Itoa(keySize))
 	}

--- a/argon2i_test.go
+++ b/argon2i_test.go
@@ -34,15 +34,15 @@ func TestArgon2i(t *testing.T) {
 	}
 
 	t.Run(testFn("generate salt", "$argon2i$v=19$m=65536,t=2,p=4$",
-		"$argon2i$v=19$m=65536,t=2$", nil))
+		"$argon2i$v=19$m=65536,t=2,p=4$", nil))
 	t.Run(testFn("password", "$argon2i$v=19$m=65536,t=2,p=4$c29tZXNhbHQ",
-		"$argon2i$v=19$m=65536,t=2$c29tZXNhbHQ$IMit9qkFULCMA/ViizL57cnTLOa5DiVM9eMwpAvPwr4", nil))
+		"$argon2i$v=19$m=65536,t=2,p=4$c29tZXNhbHQ$IMit9qkFULCMA/ViizL57cnTLOa5DiVM9eMwpAvPwr4", nil))
 	t.Run(testFn("another password", "$argon2i$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ",
-		"$argon2i$v=19$m=65536,t=2$YW5vdGhlcnNhbHQ$BCRltpeTFX0QYrELiOXWGZniID9nOUsBPy8Bu0SE7bM", nil))
+		"$argon2i$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ$BCRltpeTFX0QYrELiOXWGZniID9nOUsBPy8Bu0SE7bM", nil))
 	t.Run(testFn("password", "$argon2i$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc",
 		"$argon2i$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$N2zfK+oCIRMbTX04zZS4X2uLKX3SK0KkNxyCw/NURrU", nil))
 	t.Run(testFn("ignore-hash-in-settings", "$argon2i$v=19$m=65536,t=2$bG9uZ3NhbHRsb25nc2FsdGxvbmc$rDmQABiNkSO3bGHbBUkShgb7wIlBP8HHfq6nDH+Sqss",
-		"$argon2i$v=19$m=65536,t=2$bG9uZ3NhbHRsb25nc2FsdGxvbmc$xY9IRFH+zQduVUYoZfSoT6tylET3/AUIOMS3rFF0x0o", nil))
+		"$argon2i$v=19$m=65536,t=2,p=4$bG9uZ3NhbHRsb25nc2FsdGxvbmc$xY9IRFH+zQduVUYoZfSoT6tylET3/AUIOMS3rFF0x0o", nil))
 	t.Run(testFn("password", "$argon2i$v=19$m=65536,t=3,p=1$bG9uZ3NhbHRsb25nc2FsdA",
 		"$argon2i$v=19$m=65536,t=3,p=1$bG9uZ3NhbHRsb25nc2FsdA$K2rLfVoQG17LuUn26otasTX1WBXjr6hi5NZXKKxmYrs", nil))
 	t.Run(testFn("password", "$argon2i$v=19$m=65536,t=3,p=1,k=64$bG9uZ3NhbHRsb25nc2FsdA",

--- a/argon2id.go
+++ b/argon2id.go
@@ -79,15 +79,9 @@ func argon2idAlgorithm(password, settings string) (string, error) {
 	hash := argon2.IDKey(passwordBytes, saltBytes, uint32(time), uint32(memory), uint8(threads), uint32(keySize))
 
 	p := []string{}
-	if memory != argon2idDefaultMemory {
-		p = append(p, "m="+strconv.Itoa(memory))
-	}
-	if time != argon2idDefaultTime {
-		p = append(p, "t="+strconv.Itoa(time))
-	}
-	if threads != argon2idDefaultThreads {
-		p = append(p, "p="+strconv.Itoa(threads))
-	}
+	p = append(p, "m="+strconv.Itoa(memory))
+	p = append(p, "t="+strconv.Itoa(time))
+	p = append(p, "p="+strconv.Itoa(threads))
 	if keySize != argon2idDefaultKeySize {
 		p = append(p, "k="+strconv.Itoa(keySize))
 	}

--- a/argon2id_test.go
+++ b/argon2id_test.go
@@ -34,11 +34,11 @@ func TestArgon2id(t *testing.T) {
 	}
 
 	t.Run(testFn("generate salt", "$argon2id$v=19$m=65536,t=2,p=4$",
-		"$argon2id$v=19$m=65536,t=2$", nil))
+		"$argon2id$v=19$m=65536,t=2,p=4$", nil))
 	t.Run(testFn("password", "$argon2id$v=19$m=65536,t=2,p=4$c29tZXNhbHQ",
-		"$argon2id$v=19$m=65536,t=2$c29tZXNhbHQ$GpZ3sK/oH9p7VIiV56G/64Zo/8GaUw434IimaPqxwCo", nil))
+		"$argon2id$v=19$m=65536,t=2,p=4$c29tZXNhbHQ$GpZ3sK/oH9p7VIiV56G/64Zo/8GaUw434IimaPqxwCo", nil))
 	t.Run(testFn("another password", "$argon2id$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ",
-		"$argon2id$v=19$m=65536,t=2$YW5vdGhlcnNhbHQ$ZU9gSnQfqeEZG2Wu6Wq9pek2UAttI/N8NLCEecVBRZc", nil))
+		"$argon2id$v=19$m=65536,t=2,p=4$YW5vdGhlcnNhbHQ$ZU9gSnQfqeEZG2Wu6Wq9pek2UAttI/N8NLCEecVBRZc", nil))
 	t.Run(testFn("password", "$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc",
 		"$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$y3Tz6SCUIw7occvkgsUYx0hwaePXLus7rxUzsOghhnE", nil))
 	t.Run(testFn("ignore-hash-in-settings", "$argon2id$v=19$m=65536,t=2,p=1$bG9uZ3NhbHRsb25nc2FsdGxvbmc$y3Tz6SCUIw7occvkgsUYx0hwaePXLus7rxUzsOghhnE",


### PR DESCRIPTION
DRAFT because I couldn't find any docs on the encoding format for argon2i/argon2id strings other than this which lead to the IETF specs I think:

Encoding Format: https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#argon2-encoding
IETF Specification: https://tools.ietf.org/html/draft-irtf-cfrg-argon2-10

"The parameters shall appear in the m,t,p,keyid,data order. The keyid and data parameters are optional; the three others are NOT optional."